### PR TITLE
Change file() to open() in htmltrace.py

### DIFF
--- a/ccm/ui/htmltrace.py
+++ b/ccm/ui/htmltrace.py
@@ -234,7 +234,7 @@ class HTMLTrace:
     fixed=self.makeFixedTable(fixed_keys)    
     
     if not filename.endswith('.html'): filename+='.html'    
-    f=file(filename,'w')
+    f=open(filename,'w')
     
     page=html[
            head[

--- a/pm_2.py
+++ b/pm_2.py
@@ -6,18 +6,18 @@ log=ccm.log()
 # define the model
 class MyModel(ACTR):
     goal=Buffer()
-    
+
     def greeting1(goal='action:greet style:casual person:?name'):
         print("Hi",name)
         goal.clear()
-        
+
     def greeting2(goal='action:greet style:formal person:?name'):
         print("Greetings",name)
         goal.clear()
-        
-        
-        
-# run the model        
+
+
+
+# run the model
 model=MyModel()
 ccm.log_everything(model)
 #model.goal.set('action:greet style:formal person:Terry')

--- a/pm_3.py
+++ b/pm_3.py
@@ -8,30 +8,30 @@ class ExpertCountingModel(ACTR):
     goal=Buffer()
 
     def countFromOne(goal='action:counting current:one target:!one'):
-        goal.modify(current='two')        
+        goal.modify(current='two')
     def countFromTwo(goal='action:counting current:two target:!two'):
-        goal.modify(current='three')        
+        goal.modify(current='three')
     def countFromThree(goal='action:counting current:three target:!three'):
-        goal.modify(current='four')        
+        goal.modify(current='four')
     def countFromFour(goal='action:counting current:four target:!four'):
-        goal.modify(current='five')        
+        goal.modify(current='five')
     def countFromFive(goal='action:counting current:five target:!five'):
-        goal.modify(current='six')        
+        goal.modify(current='six')
     def countFromSix(goal='action:counting current:six target:!six'):
-        goal.modify(current='seven')        
+        goal.modify(current='seven')
     def countFromSeven(goal='action:counting current:seven target:!seven'):
-        goal.modify(current='eight')        
+        goal.modify(current='eight')
     def countFromEight(goal='action:counting current:eight target:!eight'):
-        goal.modify(current='nine')        
+        goal.modify(current='nine')
     def countFromNine(goal='action:counting current:nine target:!nine'):
-        goal.modify(current='ten')        
-        
+        goal.modify(current='ten')
+
     def countFinished(goal='action:counting current:?x target:?x'):
         print('Finished counting to',x)
         goal.clear()
-        
-        
-# run the model        
+
+
+# run the model
 model=ExpertCountingModel()
 ccm.log_everything(model)
 model.goal.set('action:counting current:one target:five')


### PR DESCRIPTION
Python3 was failing to run the htmltrace.generate() fn, on line 237.  Changed keyword/builtin from 'file' to 'open'.

Also removed some trailing whitespace.